### PR TITLE
chore: use bytecode-version 6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ build
 
 node_modules
 .env
+artifacts

--- a/aptos/build.sh
+++ b/aptos/build.sh
@@ -6,5 +6,5 @@ then
     exit
 fi
 
-aptos move compile --save-metadata --package-dir aptos/modules/axelar
-aptos move compile --save-metadata --package-dir aptos/modules/test
+aptos move compile --save-metadata --bytecode-version 6 --package-dir aptos/modules/axelar
+aptos move compile --save-metadata --bytecode-version 6 --package-dir aptos/modules/test

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@axelar-network/axelar-cgp-aptos",
-  "version": "1.0.0",
+  "version": "1.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@axelar-network/axelar-cgp-aptos",
-      "version": "1.0.0",
+      "version": "1.3.1",
       "dependencies": {
         "aptos": "^1.3.16",
         "dotenv": "^16.0.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@axelar-network/axelar-cgp-aptos",
-  "version": "1.3.1",
+  "version": "1.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@axelar-network/axelar-cgp-aptos",
-      "version": "1.3.1",
+      "version": "1.0.3",
       "dependencies": {
         "aptos": "^1.3.16",
         "dotenv": "^16.0.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axelar-network/axelar-cgp-aptos",
-  "version": "1.3.1",
+  "version": "1.0.3",
   "description": "",
   "scripts": {
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axelar-network/axelar-cgp-aptos",
-  "version": "1.0.2",
+  "version": "1.3.1",
   "description": "",
   "scripts": {
     "test": "jest",


### PR DESCRIPTION
Fix build error
```
npm ERR! code 1
npm ERR! path /Users/rpzy/workspace/near-axelar-local-dev/node_modules/@axelar-network/axelar-cgp-aptos
npm ERR! command failed
npm ERR! command sh -c -- run-s build
npm ERR! > @axelar-network/axelar-cgp-aptos@1.0.2 build
npm ERR! > run-s build-aptos
npm ERR! 
npm ERR! 
npm ERR! > @axelar-network/axelar-cgp-aptos@1.0.2 build-aptos
npm ERR! > ./aptos/build.sh
npm ERR! Compiling, may take a little while to download git dependencies...
npm ERR! UPDATING GIT DEPENDENCY https://github.com/aptos-labs/aptos-core.git
npm ERR! INCLUDING DEPENDENCY AptosFramework
npm ERR! INCLUDING DEPENDENCY AptosStdlib
npm ERR! INCLUDING DEPENDENCY MoveStdlib
npm ERR! BUILDING AxelarFramework
npm ERR! thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Loading or casting u16, u32, u256 integers not supported in bytecode version 5', /Users/brew/Library/Caches/Homebrew/cargo_cache/git/checkouts/move-0639dd674f581c30/2336fe2/language/move-compiler/src/compiled_unit.rs:198:18
npm ERR! note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
npm ERR! Compiling, may take a little while to download git dependencies...
npm ERR! UPDATING GIT DEPENDENCY https://github.com/aptos-labs/aptos-core.git
npm ERR! UPDATING GIT DEPENDENCY https://github.com/aptos-labs/aptos-core.git
npm ERR! INCLUDING DEPENDENCY AptosFramework
npm ERR! INCLUDING DEPENDENCY AptosStdlib
npm ERR! INCLUDING DEPENDENCY AxelarFramework
npm ERR! INCLUDING DEPENDENCY MoveStdlib
npm ERR! BUILDING HelloWorld
npm ERR! thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Loading or casting u16, u32, u256 integers not supported in bytecode version 5', /Users/brew/Library/Caches/Homebrew/cargo_cache/git/checkouts/move-0639dd674f581c30/2336fe2/language/move-compiler/src/compiled_unit.rs:198:18
npm ERR! note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
npm ERR! ERROR: "build-aptos" exited with 101.
npm ERR! ERROR: "build" exited with 1.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/rpzy/.npm/_logs/2023-03-15T08_35_29_767Z-debug-0.log
```