### PR TITLE
chore: use bash for build-aptos script

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@axelar-network/axelar-cgp-aptos",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "",
   "scripts": {
     "test": "jest",
-    "build-aptos": "./aptos/build.sh",
+    "build-aptos": "bash ./aptos/build.sh",
     "build": "run-s build-aptos",
     "postinstall": "run-s build",
     "lint": "eslint 'test/**/*.js'",


### PR DESCRIPTION
This just works, i don't know exactly why 🤷🏻‍♂️

Tested on `ubuntu:22.10`

Without bash
```

> npty-axelar-cgp-aptos@1.0.4 postinstall
> run-s build


> npty-axelar-cgp-aptos@1.0.4 build
> run-s build-aptos


> npty-axelar-cgp-aptos@1.0.4 build-aptos
> ./aptos/build.sh

aptos not found. skip building modules.
/usr/local/bin/aptos
```

With bash:
```
> npty-axelar-cgp-aptos@1.0.4 postinstall
> run-s build


> npty-axelar-cgp-aptos@1.0.4 build
> run-s build-aptos


> npty-axelar-cgp-aptos@1.0.4 build-aptos
> bash ./aptos/build.sh

Compiling, may take a little while to download git dependencies...
UPDATING GIT DEPENDENCY https://github.com/aptos-labs/aptos-core.git
INCLUDING DEPENDENCY AptosFramework
INCLUDING DEPENDENCY AptosStdlib
INCLUDING DEPENDENCY MoveStdlib
BUILDING AxelarFramework
{
  "Result": [
    "e2a20d8c426eb04d882e20e78399b24123905d9f1adf95a292832805965e263a::address_utils",
    "e2a20d8c426eb04d882e20e78399b24123905d9f1adf95a292832805965e263a::axelar_gas_service",
    "e2a20d8c426eb04d882e20e78399b24123905d9f1adf95a292832805965e263a::gateway"
  ]
}
Compiling, may take a little while to download git dependencies...
UPDATING GIT DEPENDENCY https://github.com/aptos-labs/aptos-core.git
UPDATING GIT DEPENDENCY https://github.com/aptos-labs/aptos-core.git
INCLUDING DEPENDENCY AptosFramework
INCLUDING DEPENDENCY AptosStdlib
INCLUDING DEPENDENCY AxelarFramework
INCLUDING DEPENDENCY MoveStdlib
BUILDING HelloWorld
{
  "Result": [
    "8ac1b8ff9583ac8e661c7f0ee462698c57bb7fc454f587e3fa25a57f9406acc0::hello_world"
  ]
}
```