### PR TITLE
chore: lock aptos version

### DIFF
--- a/aptos/modules/axelar/Move.toml
+++ b/aptos/modules/axelar/Move.toml
@@ -6,4 +6,4 @@ version = "0.0.2"
 axelar = "0xe2a20d8c426eb04d882e20e78399b24123905d9f1adf95a292832805965e263a"
 
 [dependencies]
-AptosFramework = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-framework", rev = "main"}
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-framework", rev = "3fc3d42"}

--- a/aptos/modules/test/Move.toml
+++ b/aptos/modules/test/Move.toml
@@ -7,5 +7,5 @@ axelar = "0xe2a20d8c426eb04d882e20e78399b24123905d9f1adf95a292832805965e263a"
 hello_world = "0x8ac1b8ff9583ac8e661c7f0ee462698c57bb7fc454f587e3fa25a57f9406acc0"
 
 [dependencies]
-AptosFramework = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-framework", rev = "main"}
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-framework", rev = "3fc3d42"}
 AxelarFramework = { local = "../axelar" }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@axelar-network/axelar-cgp-aptos",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@axelar-network/axelar-cgp-aptos",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "hasInstallScript": true,
       "license": "ISC"
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axelar-network/axelar-cgp-aptos",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "",
   "files": [
     "aptos/modules/axelar"


### PR DESCRIPTION
# Description
Our Aptos modules cannot be compiled right now because the `AptosFramework` dependency is set to `main` branch and it looks like that makes our compilation failed.

```
Compiling, may take a little while to download git dependencies...
UPDATING GIT DEPENDENCY https://github.com/aptos-labs/aptos-core.git
INCLUDING DEPENDENCY AptosFramework
INCLUDING DEPENDENCY AptosStdlib
INCLUDING DEPENDENCY MoveStdlib
BUILDING AxelarFramework
error: property `map_borrow_mut_with_default` is not valid in this context
   ┌─ /Users/rpzy/.move/https___github_com_aptos-labs_aptos-core_git_main/aptos-move/framework/aptos-framework/../aptos-stdlib/sources/table.spec.move:7:9
   │  
 7 │ ╭         pragma intrinsic = map,
 8 │ │             map_new = new,
 9 │ │             map_destroy_empty = destroy,
10 │ │             map_has_key = contains,
   · │
19 │ │             map_spec_del = spec_remove,
20 │ │             map_spec_has_key = spec_contains;
   │ ╰─────────────────────────────────────────────^

error: property `map_borrow_mut_with_default` is not valid in this context
   ┌─ /Users/rpzy/.move/https___github_com_aptos-labs_aptos-core_git_main/aptos-move/framework/aptos-framework/../aptos-stdlib/sources/table_with_length.spec.move:7:9
   │  
 7 │ ╭         pragma intrinsic = map,
 8 │ │             map_new = new,
 9 │ │             map_destroy_empty = destroy_empty,
10 │ │             map_len = length,
   · │
22 │ │             map_spec_len = spec_len,
23 │ │             map_spec_has_key = spec_contains;
   │ ╰─────────────────────────────────────────────^

{
  "Error": "Move compilation failed: extended checks failed"
}
``` 

This PR locks the `AptosFramework` dependency version to latest compilable version.

Tested result
```
➜  axelar-cgp-aptos git:(main) ✗ make compile
bash ./build.sh
Compiling, may take a little while to download git dependencies...
FETCHING GIT DEPENDENCY https://github.com/aptos-labs/aptos-core.git
INCLUDING DEPENDENCY AptosFramework
INCLUDING DEPENDENCY AptosStdlib
INCLUDING DEPENDENCY MoveStdlib
BUILDING AxelarFramework
{
  "Result": [
    "e2a20d8c426eb04d882e20e78399b24123905d9f1adf95a292832805965e263a::address_utils",
    "e2a20d8c426eb04d882e20e78399b24123905d9f1adf95a292832805965e263a::axelar_gas_service",
    "e2a20d8c426eb04d882e20e78399b24123905d9f1adf95a292832805965e263a::gateway"
  ]
}
```